### PR TITLE
Fix script-5.py for modern python

### DIFF
--- a/dft-scripts/script-5.py
+++ b/dft-scripts/script-5.py
@@ -1,5 +1,5 @@
 from ase.data import g2
-keys = g2.data.keys()
+keys = list(g2.data.keys())
 # print in 3 columns
-for i in range(len(keys) / 3):
+for i in range(int(len(keys) / 3)):
     print('{0:25s}{1:25s}{2:25s}'.format(*tuple(keys[i * 3: i * 3 + 3])))

--- a/dft-scripts/script-6.py
+++ b/dft-scripts/script-6.py
@@ -1,4 +1,4 @@
-from ase.structure import molecule
+from ase.build import molecule
 from ase.io import write
 atoms = molecule('CH3CN')
 atoms.center(vacuum=6)


### PR DESCRIPTION
range must be an int: g2 data set has 162 keys, 162 / 3 =  54.0, cast 54.0 to 54

dict_keys is not subscriptable, use a list of keys instead